### PR TITLE
Allow username to be set when fetching the host key

### DIFF
--- a/host_key_getter.go
+++ b/host_key_getter.go
@@ -14,12 +14,17 @@ type KeyGetter interface {
 type HostKeyGetter struct {
 	publicKeyChannel chan ssh.PublicKey
 	dialErrorChannel chan error
+	username         string
 }
 
-func NewHostKeyGetter() HostKeyGetter {
+func NewHostKeyGetter(username string) HostKeyGetter {
+	if username == "" {
+		username = "jumpbox"
+	}
 	return HostKeyGetter{
 		publicKeyChannel: make(chan ssh.PublicKey),
 		dialErrorChannel: make(chan error),
+		username:         username,
 	}
 }
 
@@ -30,7 +35,7 @@ func (h HostKeyGetter) Get(key, serverURL string) (ssh.PublicKey, error) {
 	}
 
 	clientConfig := &ssh.ClientConfig{
-		User: "jumpbox",
+		User: h.username,
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),
 		},

--- a/host_key_getter_test.go
+++ b/host_key_getter_test.go
@@ -20,15 +20,28 @@ var _ = Describe("HostKeyGetter", func() {
 			Expect(err).NotTo(HaveOccurred())
 			key = signer.PublicKey()
 
-			sshServerAddr = proxy.StartTestSSHServer("", sshPrivateKey)
+			sshServerAddr = proxy.StartTestSSHServer("", sshPrivateKey, "")
 
-			hostKeyGetter = proxy.NewHostKeyGetter()
+			hostKeyGetter = proxy.NewHostKeyGetter("")
 		})
 
 		It("returns the host key", func() {
 			hostKey, err := hostKeyGetter.Get(sshPrivateKey, sshServerAddr)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(hostKey).To(Equal(key))
+		})
+
+		Context("when a username has been set", func(){
+			BeforeEach(func(){
+				sshServerAddr = proxy.StartTestSSHServer("", sshPrivateKey, "different-username")
+				hostKeyGetter = proxy.NewHostKeyGetter("different-username")
+			})
+
+			It("returns the host key", func() {
+				hostKey, err := hostKeyGetter.Get(sshPrivateKey, sshServerAddr)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(hostKey).To(Equal(key))
+			})
 		})
 
 		Context("failure cases", func() {

--- a/socks5_proxy_test.go
+++ b/socks5_proxy_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Socks5Proxy", func() {
 		}))
 		httpServerHostPort = strings.Split(httpServer.URL, "http://")[1]
 
-		sshServerURL = proxy.StartTestSSHServer(httpServerHostPort, sshPrivateKey)
+		sshServerURL = proxy.StartTestSSHServer(httpServerHostPort, sshPrivateKey, "")
 
 		var err error
 		signer, err = ssh.ParsePrivateKey([]byte(sshPrivateKey))

--- a/ssh_test_server.go
+++ b/ssh_test_server.go
@@ -9,7 +9,11 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func StartTestSSHServer(httpServerURL, sshPrivateKey string) string {
+func StartTestSSHServer(httpServerURL, sshPrivateKey, userName string) string {
+	if userName == "" {
+		userName = "jumpbox"
+	}
+
 	signer, err := ssh.ParsePrivateKey([]byte(sshPrivateKey))
 	if err != nil {
 		log.Fatal("Failed to parse private key: ", err)
@@ -17,6 +21,10 @@ func StartTestSSHServer(httpServerURL, sshPrivateKey string) string {
 
 	config := &ssh.ServerConfig{
 		PublicKeyCallback: func(c ssh.ConnMetadata, pubKey ssh.PublicKey) (*ssh.Permissions, error) {
+			if c.User() != userName {
+				return nil, fmt.Errorf("unknown user: %q", c.User())
+			}
+
 			if string(signer.PublicKey().Marshal()) == string(pubKey.Marshal()) {
 				return nil, nil
 			}

--- a/ssh_test_server_test.go
+++ b/ssh_test_server_test.go
@@ -37,7 +37,7 @@ var _ = Describe("StartTestSSHServer", func() {
 	})
 
 	It("accepts multiple requests", func() {
-		url := proxy.StartTestSSHServer(httpServerHostPort, sshPrivateKey)
+		url := proxy.StartTestSSHServer(httpServerHostPort, sshPrivateKey, "")
 
 		conn1, err := ssh.Dial("tcp", url, clientConfig)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
- This allows this library to be used more generally, where the username is not jumpbox.

The would allow me to more easily generalize the usage in the bosh-deployment-resource for [this issue](https://github.com/cloudfoundry/bosh-deployment-resource/issues/24)