### PR TITLE
Allow user to specify logger

### DIFF
--- a/socks5_proxy.go
+++ b/socks5_proxy.go
@@ -10,6 +10,7 @@ import (
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/context"
+	"log"
 )
 
 var netListen = net.Listen
@@ -24,12 +25,14 @@ type Socks5Proxy struct {
 	hostKey hostKey
 	port    int
 	started bool
+	logger  *log.Logger
 }
 
-func NewSocks5Proxy(hostKey hostKey) *Socks5Proxy {
+func NewSocks5Proxy(hostKey hostKey, logger *log.Logger) *Socks5Proxy {
 	return &Socks5Proxy{
 		hostKey: hostKey,
 		started: false,
+		logger:  logger,
 	}
 }
 
@@ -87,6 +90,7 @@ func (s *Socks5Proxy) StartWithDialer(dialer DialFunc) error {
 		Dial: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return dialer(network, addr)
 		},
+		Logger: s.logger,
 	}
 
 	server, err := socks5.New(conf)

--- a/socks5_proxy_test.go
+++ b/socks5_proxy_test.go
@@ -40,7 +40,8 @@ var _ = Describe("Socks5Proxy", func() {
 		hostKey = &fakes.HostKey{}
 		hostKey.GetCall.Returns.PublicKey = signer.PublicKey()
 
-		socks5Proxy = proxy.NewSocks5Proxy(hostKey)
+
+		socks5Proxy = proxy.NewSocks5Proxy(hostKey, nil) //sock5 server defaults to a stdout logger for us
 	})
 
 	AfterEach(func() {
@@ -179,7 +180,7 @@ var _ = Describe("Socks5Proxy", func() {
 				hostKey = &fakes.HostKey{}
 				hostKey.GetCall.Returns.PublicKey = signer.PublicKey()
 
-				socks5Proxy = proxy.NewSocks5Proxy(hostKey)
+				socks5Proxy = proxy.NewSocks5Proxy(hostKey, nil) //sock5 server defaults to a stdout logger for us
 			})
 
 			It("returns a dialer that proxies to the jumpbox with a custom user", func() {


### PR DESCRIPTION
- The socks5 library we use defaults the logger to stdout if no logger is specified

https://github.com/cloudfoundry/socks5-proxy/issues/3