### PR TITLE
Allow proxy.Start() to receive username

### DIFF
--- a/socks5_proxy.go
+++ b/socks5_proxy.go
@@ -36,12 +36,12 @@ func NewSocks5Proxy(hostKey hostKey, logger *log.Logger) *Socks5Proxy {
 	}
 }
 
-func (s *Socks5Proxy) Start(key, url string) error {
+func (s *Socks5Proxy) Start(username, key, url string) error {
 	if s.started {
 		return nil
 	}
 
-	dialer, err := s.Dialer("", key, url)
+	dialer, err := s.Dialer(username, key, url)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Not every environment will have a username named 'jumpbox', this makes it so
that the consumer has to pass a username (or "" for the default of jumpbox),
similar to the Dialer.
