### PR TITLE
Add Socks5Proxy.SetListenPort

### DIFF
--- a/socks5_proxy.go
+++ b/socks5_proxy.go
@@ -42,6 +42,10 @@ func NewSocks5Proxy(hostKey hostKey, logger *log.Logger, keepAliveInterval time.
 	}
 }
 
+func (s *Socks5Proxy) SetListenPort(port int) {
+	s.port = port
+}
+
 func (s *Socks5Proxy) Start(username, key, url string) error {
 	if s.isStarted() {
 		return nil

--- a/socks5_proxy_test.go
+++ b/socks5_proxy_test.go
@@ -274,4 +274,114 @@ var _ = Describe("Socks5Proxy", func() {
 			})
 		})
 	})
+
+	Describe("SetListenPort", func() {
+		Context("when empty username is given", func() {
+			It("starts a proxy to the jumpbox", func() {
+				serverURL := proxy.StartTestSSHServer(httpServerHostPort, privateKey, "")
+				socks5Proxy.SetListenPort(1337)
+				err := socks5Proxy.Start("", privateKey, serverURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Wait for socks5 proxy to start
+				time.Sleep(1 * time.Second)
+
+				socks5Addr, err := socks5Proxy.Addr()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(strings.Contains(socks5Addr, ":1337")).To(Equal(true))
+
+				socks5Client, err := goproxy.SOCKS5("tcp", socks5Addr, nil, goproxy.Direct)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(hostKey.GetCall.CallCount).To(Equal(1))
+				Expect(hostKey.GetCall.Receives.Username).To(Equal("jumpbox"))
+				Expect(hostKey.GetCall.Receives.PrivateKey).To(Equal(privateKey))
+				Expect(hostKey.GetCall.Receives.ServerURL).To(Equal(serverURL))
+
+				conn, err := socks5Client.Dial("tcp", httpServerHostPort)
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = conn.Write([]byte("GET / HTTP/1.0\r\n\r\n"))
+				Expect(err).NotTo(HaveOccurred())
+				defer conn.Close()
+
+				status, err := bufio.NewReader(conn).ReadString('\n')
+				Expect(status).To(Equal("HTTP/1.0 200 OK\r\n"))
+			})
+
+			Context("when starting the proxy a second time", func() {
+				It("no-ops on the second run", func() {
+					serverURL := proxy.StartTestSSHServer(httpServerHostPort, privateKey, "")
+					err := socks5Proxy.Start("", privateKey, serverURL)
+					Expect(err).NotTo(HaveOccurred())
+
+					// Wait for socks5 proxy to start
+					time.Sleep(1 * time.Second)
+
+					err = socks5Proxy.Start("", privateKey, serverURL)
+					Expect(err).NotTo(HaveOccurred())
+
+					socks5Addr, err := socks5Proxy.Addr()
+					Expect(err).NotTo(HaveOccurred())
+
+					socks5Client, err := goproxy.SOCKS5("tcp", socks5Addr, nil, goproxy.Direct)
+					Expect(err).NotTo(HaveOccurred())
+
+					conn, err := socks5Client.Dial("tcp", httpServerHostPort)
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = conn.Write([]byte("GET / HTTP/1.0\r\n\r\n"))
+					Expect(err).NotTo(HaveOccurred())
+					defer conn.Close()
+
+					status, err := bufio.NewReader(conn).ReadString('\n')
+					Expect(status).To(Equal("HTTP/1.0 200 OK\r\n"))
+				})
+			})
+		})
+
+		Context("when a custom username is given", func() {
+			JustBeforeEach(func() {
+				signer, err := ssh.ParsePrivateKey([]byte(privateKey))
+				Expect(err).NotTo(HaveOccurred())
+
+				hostKey = &fakes.HostKey{}
+				hostKey.GetCall.Returns.PublicKey = signer.PublicKey()
+
+				socks5Proxy = proxy.NewSocks5Proxy(hostKey, nil, time.Millisecond) //sock5 server defaults to a stdout logger for us
+			})
+
+			It("returns a dialer that proxies to the jumpbox with a custom user", func() {
+				serverURL := proxy.StartTestSSHServer(httpServerHostPort, privateKey, "custom-username")
+				err := socks5Proxy.Start("custom-username", privateKey, serverURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Wait for socks5 proxy to start
+				time.Sleep(1 * time.Second)
+
+				socks5Addr, err := socks5Proxy.Addr()
+				Expect(err).NotTo(HaveOccurred())
+
+				socks5Client, err := goproxy.SOCKS5("tcp", socks5Addr, nil, goproxy.Direct)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(hostKey.GetCall.CallCount).To(Equal(1))
+				Expect(hostKey.GetCall.Receives.Username).To(Equal("custom-username"))
+				Expect(hostKey.GetCall.Receives.PrivateKey).To(Equal(privateKey))
+				Expect(hostKey.GetCall.Receives.ServerURL).To(Equal(serverURL))
+
+				conn, err := socks5Client.Dial("tcp", httpServerHostPort)
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = conn.Write([]byte("GET / HTTP/1.0\r\n\r\n"))
+				Expect(err).NotTo(HaveOccurred())
+				defer conn.Close()
+
+				status, err := bufio.NewReader(conn).ReadString('\n')
+				Expect(status).To(Equal("HTTP/1.0 200 OK\r\n"))
+			})
+		})
+	})
+
+
 })


### PR DESCRIPTION
Currently the proxy dynamicly uses a listen port for the SOCKS5 channel. This PR adds functionality to set a static listen port which is needed in certain scenarios. It is a method addition and doesn't break the existing API.